### PR TITLE
add unix socket support

### DIFF
--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -144,6 +144,7 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
       return this.readSInt16();
     case 'q':
       return this.readInt16();
+    case 'h': // unix socket is just a number
     case 'u':
       return this.readInt32();
     case 'i':


### PR DESCRIPTION
This adds support for unix-sockets.
Those are nothing else then unsigned 32-bit integers.
See UNIX_FD: https://dbus.freedesktop.org/doc/dbus-specification.html#basic-types

For example Bluez use those to hand over a communication socket to the application.