### PR TITLE
Lazily add bus matches

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -449,7 +449,19 @@ class MessageBus extends EventEmitter {
       body: [match]
     });
     return this.call(msg);
-  };
+  }
+
+  _removeMatch(match) {
+    let msg = new Message({
+      path: '/org/freedesktop/DBus',
+      destination: 'org.freedesktop.DBus',
+      interface: 'org.freedesktop.DBus',
+      member: 'RemoveMatch',
+      signature: 's',
+      body: [match]
+    });
+    return this.call(msg);
+  }
 };
 
 module.exports = MessageBus;

--- a/lib/client/proxy-interface.js
+++ b/lib/client/proxy-interface.js
@@ -68,6 +68,7 @@ class ProxyInterface extends EventEmitter {
         return;
       }
 
+      this.$object.bus._removeMatch(this._signalMatchRuleString(eventName));
       this.$object.bus._signals.removeListener(detailedEvent, this._getEventListener(signal));
     });
 
@@ -78,8 +79,13 @@ class ProxyInterface extends EventEmitter {
         return;
       }
 
+      this.$object.bus._addMatch(this._signalMatchRuleString(eventName));
       this.$object.bus._signals.on(detailedEvent, this._getEventListener(signal));
     });
+  }
+
+  _signalMatchRuleString(eventName) {
+    return `type='signal',sender=${this.$object.name},interface='${this.$name}',path='${this.$object.path}',member='${eventName}'`
   }
 
   _getEventListener(signal) {

--- a/lib/client/proxy-object.js
+++ b/lib/client/proxy-object.js
@@ -107,7 +107,6 @@ class ProxyObject {
         let iface = ProxyInterface._fromXml(this, i);
         if (iface !== null) {
           this.interfaces[iface.$name] = iface;
-          this.bus._addMatch(`type='signal',sender=${this.name},interface='${iface.$name}',path='${this.path}'`);
         }
       }
     }

--- a/test/integration/signals.test.js
+++ b/test/integration/signals.test.js
@@ -114,6 +114,12 @@ test('test that signals work correctly', async () => {
   expect(bus._signals.eventNames().length).toEqual(2);
   test.removeListener('SignalMultiple', onSignalMultiple);
   expect(bus._signals.eventNames().length).toEqual(2);
+
+  // removing the listener on a signal should not remove them all
+  onSignalMultiple2.mockClear()
+  await test.EmitSignals();
+  expect(onSignalMultiple2).toHaveBeenCalledWith('hello', 'world');
+
   test.removeListener('SignalMultiple', onSignalMultiple2);
   expect(bus._signals.eventNames().length).toEqual(1);
   test.removeListener('SignalComplicated', onSignalComplicated);


### PR DESCRIPTION
Similar to how event listeners on signals are lazily added (ref
bd08f64), add a match when the user listens to a signal and remove the
match when the event listener is removed.

ref #39