### PR TITLE
Fix object name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ let methodCall = new Message({
   member: 'ListNames'
 });
 
-let reply = await bus.call(message);
+let reply = await bus.call(methodCall);
 console.log('names on the bus: ', reply.body[0]);
 
 // add a custom handler for a particular method


### PR DESCRIPTION
The object name in example should be `methodCall` but is `message`.