### PR TITLE
fix(types): fix call signature for `sessionBus`

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -133,5 +133,5 @@ declare module 'dbus-next' {
     }
 
     export function systemBus(): MessageBus;
-    export function sessionBus(options?: SessionBusOptions): MessageBus;
+    export function sessionBus(options?: BusOptions): MessageBus;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -125,6 +125,14 @@ declare module 'dbus-next' {
         [name: string]: Function;
     }
 
+    export type AuthMethod = 'EXTERNAL' | 'DBUS_COOKIE_SHA1' | 'ANONYMOUS';
+
+    export interface SessionBusOptions {
+        authMethods?: AuthMethod[];
+        busAddress?: string;
+        ayBuffer?: boolean;
+    }
+
     export function systemBus(): MessageBus;
-    export function sessionBus(options: any): MessageBus;
+    export function sessionBus(options?: SessionBusOptions): MessageBus;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -127,10 +127,9 @@ declare module 'dbus-next' {
 
     export type AuthMethod = 'EXTERNAL' | 'DBUS_COOKIE_SHA1' | 'ANONYMOUS';
 
-    export interface SessionBusOptions {
+    export interface BusOptions {
         authMethods?: AuthMethod[];
         busAddress?: string;
-        ayBuffer?: boolean;
     }
 
     export function systemBus(): MessageBus;


### PR DESCRIPTION
The `options` argument is optional, and it is an object with known properties.