### PR TITLE
added support for no reply methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ class ExampleInterface extends Interface {
     throw new DBusError('org.test.iface.Error', 'something went wrong');
   }
 
+  @method({inSignature: '', outSignature: '', noReply: true})
+  NoReply() {
+    // by setting noReply to true, dbus-next will NOT send a return reply through dbus 
+    // after the method is called.
+  }
+
   @signal({signature: 's'})
   HelloWorld(value) {
     return value;

--- a/examples/service/index.js
+++ b/examples/service/index.js
@@ -48,6 +48,11 @@ class ExampleInterface extends Interface {
     throw new DBusError('org.test.iface.Error', 'something went wrong');
   }
 
+  @method({inSignature: '', outSignature: '', noReply: true})
+  NoReply() {
+
+  }
+
   @signal({signature: 's'})
   HelloWorld(value) {
     return value;

--- a/lib/service/handlers.js
+++ b/lib/service/handlers.js
@@ -316,6 +316,7 @@ function handleMessage(msg, bus) {
       }
 
       const sendReply = (body) => {
+        if (method.noReply) return;
         if (body === undefined) {
           body = [];
         } else if (method.outSignatureTree.length === 1) {

--- a/lib/service/interface.js
+++ b/lib/service/interface.js
@@ -401,7 +401,8 @@ class Interface {
         $: {
           name: method.name
         },
-        arg: []
+        arg: [],
+        annotation: []
       };
 
       for (let signature of method.inSignatureTree) {
@@ -420,6 +421,15 @@ class Interface {
             type: collapseSignature(signature)
           }
         });
+      }
+
+      if(method.noReply) {
+        methodXml.annotation.push({
+            $: {
+                name: 'org.freedesktop.DBus.Method.NoReply',
+                value: 'true'
+            }
+        })
       }
 
       xml.method.push(methodXml);

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -26,6 +26,11 @@ class IntrospectionTestInterface extends Interface {
     return [ str, d ];
   }
 
+  @method({inSignature: '', outSignature: '', noReply: true})
+  NoReplyMethod() {
+
+  }
+
   @method({name: 'Overloaded', inSignature: 's', outSignature: 's'})
   overloaded1(str) {
     return str;
@@ -109,6 +114,11 @@ test('method xml introspection', () => {
 
   method = getMethod('DisabledMethod')[0];
   expect(method).not.toBeDefined();
+
+  method = getMethod('NoReplyMethod')[0];
+  expect(method).toBeDefined();
+  expect(method.annotation).toBeInstanceOf(Array);
+  expect(method.annotation[0]).toEqual({'$': { name: 'org.freedesktop.DBus.Method.NoReply', value: 'true' }});
 
   let overloaded = getMethod('Overloaded');
   expect(overloaded.length).toEqual(2);


### PR DESCRIPTION
I was working with the bluez dbus api and there are several methods that error with AccessDenied because they are not expecting a reply at all. So to avoid having to add a customer handler for all the methods I added simple way to indicate that a method does not need to send a reply.

Example
```js
@method({inSignature: '', outSignature: null})
MethodWithNoReply() {

}
```

I thought you might be interested in this because this use case is called out in the readme for the customer message handler.