### PR TITLE
check stream open before writing

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -342,7 +342,8 @@ class MessageBus extends EventEmitter {
           }
         };
       }
-      this._connection.message(msg);
+      if(this._connection.stream.writable)
+        this._connection.message(msg);
     });
   };
 


### PR DESCRIPTION
Running test suites which setup and teardown in quick succession I often get an unhandled promise rejection from a write call to a closed stream. This just makes sure its writable before writing.

Error [ERR_STREAM_WRITE_AFTER_END]: write after end
    at writeAfterEnd (_stream_writable.js:248:12)
    at Socket.Writable.write (_stream_writable.js:296:5)
    at EventEmitter.self.message (node_modules/dbus-next/lib/connection.js:134:14)
    at Promise (node_modules/dbus-next/lib/bus.js:348:30)
    at new Promise (<anonymous>)
    at MessageBus.call node_modules/dbus-next/lib/bus.js:322:12)
    at MessageBus._removeMatch (node_modules/dbus-next/lib/bus.js:479:17)
    at ProxyInterface.on (node_modules/dbus-next/lib/client/proxy-interface.js:70:24)
    at ProxyInterface.emit (events.js:198:13)
    at ProxyInterface.removeListener (events.js:334:18)