### PR TITLE
Use USocket for UNIX_FD transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,15 @@ Each code in the signature is mapped to a JavaScript type as shown in the table 
 | STRING      | s    | string  |                                                                    |
 | OBJECT_PATH | o    | string  | Must be a valid object path                                        |
 | SIGNATURE   | g    | string  | Must be a valid signature                                          |
+| UNIX_FD     | h    | number  | Must be a valid unix file descriptor. e.g. from `fs.open()`        |
 | ARRAY       | a    | Array   | Must be followed by a complete type which specifies the child type |
 | STRUCT      | (    | Array   | Types in the JS Array must match the types between the parens      |
 | VARIANT     | v    | Variant | This class is provided by the library.                             |
 | DICT_ENTRY  | {    | Object  | Must be included in an array type to be an object.                 |
+
+Unix file descriptors are only supported on abstract or domain (path) sockets. This is the default for both system and session bus.
+When sending a file descriptor it must be kept open until the message is delivered.
+When receiving a file descriptor the application is responsible for closing it.
 
 The types `a`, `(`, `v`, and `{` are container types that hold other values. Examples of container types and JavaScript examples are in the table below.
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,7 +141,12 @@ function createConnection (opts) {
   self.once('connect', function () {
     self.state = 'connected';
     for (let i = 0; i < self._messages.length; ++i) {
-      stream.write(marshallMessage(self._messages[i]));
+      const [data, fds] = marshallMessage(self._messages[i]);
+      if(stream.supportsUnixFd) {
+        stream.write({data, fds});
+      } else {
+        stream.write(data);
+      }
     }
     self._messages.length = 0;
 
@@ -150,7 +155,12 @@ function createConnection (opts) {
       if (!stream.writable) {
         throw new Error('Cannot send message, stream is closed');
       }
-      stream.write(marshallMessage(msg));
+      const [data, fds] = marshallMessage(msg);
+      if(stream.supportsUnixFd) {
+        stream.write({data, fds});
+      } else {
+        stream.write(data);
+      }
     };
   });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -42,7 +42,10 @@ function createStream (opts) {
           }
           if (params.abstract) {
             const abs = require('abstract-socket');
-            return abs.connect('\u0000' + params.abstract);
+            const sock = abs.connect('\u0000' + params.abstract, () => {
+              sock.emit("connected");
+            });
+            return sock;
           }
           if (params.path) {
             try {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -162,6 +162,9 @@ function createConnection (opts) {
       if(stream.supportsUnixFd) {
         stream.write({data, fds});
       } else {
+        if(fds.length > 0) {
+          console.warn("Sending file descriptors is not supported in current bus connection");
+        }
         stream.write(data);
       }
     };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -45,7 +45,15 @@ function createStream (opts) {
             return abs.connect('\u0000' + params.abstract);
           }
           if (params.path) {
-            return net.createConnection(params.path);
+            try {
+              const usocket = require("usocket");
+              const sock = new usocket.USocket({path: params.path});
+              sock.supportsUnixFd = true;
+              return sock;
+            } catch(err) {
+              // TODO: maybe emit warning?
+              return net.createConnection(params.path);
+            }
           }
           throw new Error(
             "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"
@@ -57,6 +65,8 @@ function createStream (opts) {
           const args = [];
           for (let n = 1; params['arg' + n]; n++) args.push(params['arg' + n]);
           const child = spawn(params.path, args);
+          // duplex socket is auto connected so emit connect event next frame
+          setTimeout(() => eventStream.emit("connected"), 0);
 
           return eventStream.duplex(child.stdin, child.stdout);
         }
@@ -79,7 +89,7 @@ function createConnection (opts) {
   const self = new EventEmitter();
   opts = opts || {};
   const stream = (self.stream = createStream(opts));
-  stream.setNoDelay();
+  stream.setNoDelay && stream.setNoDelay();
 
   stream.on('error', function (err) {
     // forward network and stream errors
@@ -98,7 +108,7 @@ function createConnection (opts) {
     return self;
   };
 
-  clientHandshake(stream, opts, function (error, guid) {
+  function afterHandshake (error, guid) {
     if (error) {
       return self.emit('error', error);
     }
@@ -117,7 +127,9 @@ function createConnection (opts) {
       },
       opts
     );
-  });
+  }
+  stream.once("connect", () => clientHandshake(stream, opts, afterHandshake));
+  stream.once("connected", () => clientHandshake(stream, opts, afterHandshake));
 
   self._messages = [];
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -41,10 +41,9 @@ function createStream (opts) {
             return net.createConnection(params.socket);
           }
           if (params.abstract) {
-            const abs = require('abstract-socket');
-            const sock = abs.connect('\u0000' + params.abstract, () => {
-              sock.emit("connected");
-            });
+            const usocket = require("usocket");
+            const sock = new usocket.USocket({path: '\u0000' + params.abstract});
+            sock.supportsUnixFd = true;
             return sock;
           }
           if (params.path) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -263,7 +263,8 @@ module.exports = {
     'replySerial',
     'destination',
     'sender',
-    'signature'
+    'signature',
+    'unixFd'
   ],
 
   // TODO: merge to single hash? e.g path -> [1, 'o']
@@ -275,7 +276,8 @@ module.exports = {
     replySerial: 'u',
     destination: 's',
     sender: 's',
-    signature: 'g'
+    signature: 'g',
+    unixFd: 'u'
   },
   headerTypeId: {
     path: 1,
@@ -285,7 +287,8 @@ module.exports = {
     replySerial: 5,
     destination: 6,
     sender: 7,
-    signature: 8
+    signature: 8,
+    unixFd: 9
   },
   protocolVersion: 1,
   endianness: {

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -7,7 +7,7 @@ const Long = require('long');
 const LE = require('./constants').endianness.le;
 
 // Buffer + position + global start position ( used in alignment )
-function DBusBuffer (buffer, startPos, endian, options) {
+function DBusBuffer (buffer, startPos, endian, fds, options) {
   if (typeof options !== 'object') {
     options = { ayBuffer: true };
   } else if (options.ayBuffer === undefined) {
@@ -17,6 +17,7 @@ function DBusBuffer (buffer, startPos, endian, options) {
   this.options = options;
   this.buffer = buffer;
   this.endian = endian;
+  this.fds = fds;
   this.startPos = startPos || 0;
   this.pos = 0;
 }
@@ -171,7 +172,11 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType (t) {
       return this.readSInt16();
     case 'q':
       return this.readInt16();
-    case 'h': // unix socket is just a number
+    case 'h':
+      if(!this.fds || this.fds.length < 1) throw new Error("No FDs available");
+      // maybe this indicated the index in the FD array ????
+      const idx = this.readInt32(); // skip the number in the buffer
+      return this.fds.shift(); // return first FD
     case 'u':
       return this.readInt32();
     case 'i':

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -173,10 +173,9 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType (t) {
     case 'q':
       return this.readInt16();
     case 'h':
-      if(!this.fds || this.fds.length < 1) throw new Error("No FDs available");
-      // maybe this indicated the index in the FD array ????
-      const idx = this.readInt32(); // skip the number in the buffer
-      return this.fds.shift(); // return first FD
+      const idx = this.readInt32();
+      if(!this.fds || this.fds.length <= idx) throw new Error("No FDs available");
+      return this.fds[idx];
     case 'u':
       return this.readInt32();
     case 'i':

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -77,12 +77,18 @@ function tryAuth (stream, methods, cb) {
   const uid = 'getuid' in process ? process.getuid() : 0;
   const id = hexlify(uid);
 
+  let guid = "";
   function beginOrNextAuth () {
     readLine(stream, function (line) {
       const ok = line.toString('ascii').match(/^([A-Za-z]+) (.*)/);
       if (ok && ok[1] === 'OK') {
-        stream.write('BEGIN\r\n');
-        return cb(null, ok[2]); // ok[2] = guid. Do we need it?
+        guid = ok[2]; // ok[2] = guid. Do we need it?
+        if(stream.supportsUnixFd) {
+          negotiateUnixFd();
+        } else {
+          stream.write('BEGIN\r\n');
+          return cb(null, guid);
+        }
       } else {
         // TODO: parse error!
         if (!methods.empty) {
@@ -91,6 +97,21 @@ function tryAuth (stream, methods, cb) {
           return cb(line);
         }
       }
+    });
+  }
+  function negotiateUnixFd () {
+    stream.write('NEGOTIATE_UNIX_FD\r\n');
+    readLine(stream, function(line) {
+      const res = line.toString('ascii').trim();
+      if (res === "AGREE_UNIX_FD") {
+        // ok
+      } else if(res === "ERROR") {
+        stream.supportsUnixFd = false;
+      } else {
+        return cb(line);
+      }
+      stream.write('BEGIN\r\n');
+      return cb(null, guid);
     });
   }
 

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -5,7 +5,7 @@ const put = require('@nornagon/put');
 const Marshallers = require('./marshallers');
 const align = require('./align').align;
 
-module.exports = function marshall (signature, data, offset) {
+module.exports = function marshall (signature, data, offset, fds) {
   if (typeof offset === 'undefined') offset = 0;
   const tree = parseSignature(signature);
   if (!Array.isArray(data) || data.length !== tree.length) {
@@ -17,7 +17,7 @@ module.exports = function marshall (signature, data, offset) {
   }
   const putstream = put();
   putstream._offset = offset;
-  const buf = writeStruct(putstream, tree, data).buffer();
+  const buf = writeStruct(putstream, tree, data, fds).buffer();
   return buf;
 };
 
@@ -26,22 +26,22 @@ module.exports = function marshall (signature, data, offset) {
 //
 // }
 
-function writeStruct (ps, tree, data) {
+function writeStruct (ps, tree, data, fds) {
   if (tree.length !== data.length) {
     throw new Error('Invalid struct data');
   }
   for (let i = 0; i < tree.length; ++i) {
-    write(ps, tree[i], data[i]);
+    write(ps, tree[i], data[i], fds);
   }
   return ps;
 }
 
-function write (ps, ele, data) {
+function write (ps, ele, data, fds) {
   switch (ele.type) {
     case '(':
     case '{':
       align(ps, 8);
-      writeStruct(ps, ele.child, data);
+      writeStruct(ps, ele.child, data, fds);
       break;
     case 'a': {
       // array serialisation:
@@ -56,7 +56,7 @@ function write (ps, ele, data) {
       // we need to align here because alignment is not included in array length
       if (['x', 't', 'd', '{', '('].indexOf(ele.child[0].type) !== -1) { align(arrPut, 8); }
       const startOffset = arrPut._offset;
-      for (let i = 0; i < data.length; ++i) { write(arrPut, ele.child[0], data[i]); }
+      for (let i = 0; i < data.length; ++i) { write(arrPut, ele.child[0], data[i], fds); }
       const arrBuff = arrPut.buffer();
       const length = arrPut._offset - startOffset;
       // lengthOffset in the range 0 to 3 depending on number of align bytes padded _before_ arrayLength
@@ -71,12 +71,18 @@ function write (ps, ele, data) {
         type: 'g',
         child: []
       };
-      write(ps, signatureEle, data[0]);
+      write(ps, signatureEle, data[0], fds);
       const tree = parseSignature(data[0]);
       assert(tree.length === 1);
-      write(ps, tree[0], data[1]);
+      write(ps, tree[0], data[1], fds);
       break;
-    } default:
+    } case 'h': {
+      if(fds) {
+        const idx = fds.push(data);
+        return writeSimple(ps, ele.type, idx - 1);
+      }
+    }
+    default:
       return writeSimple(ps, ele.type, data);
   }
 }

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -148,6 +148,7 @@ const MakeSimpleMarshaller = function (signature) {
         ps._offset += 2;
       };
       break;
+    case 'h':
     case 'i':
       // INT32
       marshaller.check = function (data) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -97,6 +97,7 @@ module.exports.marshall = function marshallMessage (message) {
   if (message.signature && message.body) {
     bodyBuff = marshall(message.signature, message.body, 0, fds);
     bodyLength = bodyBuff.length;
+    message.unixFd = fds.length;
   }
   const header = [
     constants.endianness.le,

--- a/lib/message.js
+++ b/lib/message.js
@@ -33,13 +33,15 @@ module.exports.unmarshalMessages = function messageParser (
         bodyLength = (endian === LE ? header.readUInt32LE(4) : header.readUInt32BE(4));
         fieldsAndBodyLength = fieldsLengthPadded + bodyLength;
       } else {
-        fieldsAndBody = stream.read(fieldsAndBodyLength);
+        const readBuf = stream.read(fieldsAndBodyLength, null);
+        // usockets return object with { data, fds }
+        fieldsAndBody = readBuf ? readBuf.data || readBuf : readBuf;
         if (!fieldsAndBody) {
           break;
         }
         state = 0;
 
-        const messageBuffer = new DBusBuffer(fieldsAndBody, 0, endian, opts);
+        const messageBuffer = new DBusBuffer(fieldsAndBody, 0, endian, readBuf.fds, opts);
         const unmarshalledHeader = messageBuffer.readArray(
           headerSignature[0].child[0],
           fieldsLength
@@ -70,7 +72,7 @@ module.exports.unmarshalMessages = function messageParser (
 // TODO: factor out common code
 module.exports.unmarshall = function unmarshall (buff, opts) {
   const endian = buff.readUInt8();
-  const msgBuf = new DBusBuffer(buff, 0, endian, opts);
+  const msgBuf = new DBusBuffer(buff, 0, endian, null, opts);
   const headers = msgBuf.read('yyyyuua(yv)');
   const message = {};
   for (let i = 0; i < headers[6].length; ++i) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -93,8 +93,9 @@ module.exports.marshall = function marshallMessage (message) {
   const type = message.type || constants.messageType.METHOD_CALL;
   let bodyLength = 0;
   let bodyBuff;
+  const fds = [];
   if (message.signature && message.body) {
-    bodyBuff = marshall(message.signature, message.body);
+    bodyBuff = marshall(message.signature, message.body, 0, fds);
     bodyLength = bodyBuff.length;
   }
   const header = [
@@ -125,5 +126,5 @@ module.exports.marshall = function marshallMessage (message) {
   fieldsBuff.copy(messageBuff, headerBuff.length);
   if (bodyLength > 0) bodyBuff.copy(messageBuff, headerLenAligned);
 
-  return messageBuff;
+  return [messageBuff, fds];
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "xml2js": "^0.4.17"
   },
   "optionalDependencies": {
-    "abstract-socket": "^2.0.0"
+    "abstract-socket": "^2.0.0",
+    "usocket": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "xml2js": "^0.4.17"
   },
   "optionalDependencies": {
-    "abstract-socket": "^2.0.0",
-    "usocket": "^0.2.1"
+    "usocket": "^0.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/test/integration/fd-passing.test.js
+++ b/test/integration/fd-passing.test.js
@@ -20,8 +20,7 @@ bus.on('error', (err) => {
     console.log(`got unexpected connection error:\n${err.stack}`);
 });
 
-// if the test session was launched with dbus-run-session 
-// it will be an abstract socket which does not support unix fds
+// make sure unix fds are supported by the bus
 if(!bus._connection.stream.supportsUnixFd) {
     console.log("UNIX_FD not supported");
     test = test.skip

--- a/test/integration/fd-passing.test.js
+++ b/test/integration/fd-passing.test.js
@@ -2,7 +2,6 @@
 
 const dbus = require('../../');
 const fs = require("fs");
-const { promisify } = require("util");
 const Variant = dbus.Variant;
 const DBusError = dbus.DBusError;
 
@@ -33,10 +32,30 @@ bus2.on('error', (err) => {
     console.log(`got unexpected connection error:\n${err.stack}`);
 });
 
-
-const openFd = promisify(fs.open).bind(null, "/dev/null", "r");
-const closeFd = promisify(fs.close);
-const fstat = promisify(fs.fstat);
+function openFd() {
+    return new Promise((resolve, reject) => {
+        fs.open("/dev/null", "r", (err, fd) => {
+            if(err) reject(err);
+            else resolve(fd);
+        })
+    })
+}
+function closeFd(fd) {
+    return new Promise((resolve, reject) => {
+        fs.close(fd, (err) => {
+            if(err) reject(err);
+            else resolve();
+        })
+    })
+}
+function fstat(fd) {
+    return new Promise((resolve, reject) => {
+        fs.fstat(fd, (err, res) => {
+            if(err) reject(err);
+            else resolve(res);
+        })
+    })
+}
 async function compareFd(fd1, fd2) {
     if(!fd1 || !fd2) return;
     expect(fd1).toBeDefined();

--- a/test/integration/fd-passing.test.js
+++ b/test/integration/fd-passing.test.js
@@ -1,0 +1,194 @@
+// Test the ability to send and recv file descriptors in dbus messages.
+
+const dbus = require('../../');
+const fs = require("fs");
+const { promisify } = require("util");
+const Variant = dbus.Variant;
+const DBusError = dbus.DBusError;
+
+const {
+    Interface, property,
+    method, signal,
+    ACCESS_READ, ACCESS_WRITE
+} = dbus.interface;
+
+const TEST_NAME = 'org.test.filedescriptors';
+const TEST_PATH = '/org/test/path';
+const TEST_IFACE = 'org.test.iface';
+
+const bus = dbus.sessionBus();
+bus.on('error', (err) => {
+    console.log(`got unexpected connection error:\n${err.stack}`);
+});
+
+// if the test session was launched with dbus-run-session 
+// it will be an abstract socket which does not support unix fds
+if(!bus._connection.stream.supportsUnixFd) {
+    console.log("UNIX_FD not supported");
+    test = test.skip
+}
+
+const bus2 = dbus.sessionBus();
+bus2.on('error', (err) => {
+    console.log(`got unexpected connection error:\n${err.stack}`);
+});
+
+
+const openFd = promisify(fs.open).bind(null, "/dev/null", "r");
+const closeFd = promisify(fs.close);
+const fstat = promisify(fs.fstat);
+async function compareFd(fd1, fd2) {
+    if(!fd1 || !fd2) return;
+    expect(fd1).toBeDefined();
+    expect(fd2).toBeDefined();
+    const s1 = await fstat(fd1);
+    const s2 = await fstat(fd2);
+    //console.log(fs.readlinkSync("/proc/self/fd/"+fd1));
+    //console.log(fs.readlinkSync("/proc/self/fd/"+fd2));
+    expect(s1.ino).toEqual(s2.ino);
+    expect(s1.dev).toEqual(s2.dev);
+    expect(s1.rdev).toEqual(s2.rdev);
+}
+
+
+class TestInterface extends Interface {
+
+    constructor(name) {
+        super(name);
+        this.fds = [];
+    }
+
+    @method({ outSignature: "h" })
+    returnsFd() {
+        return this.createFd();
+    }
+
+    @method({ inSignature: "h" })
+    acceptsFd(fd) {
+        this.fds.push(fd);
+    }
+
+    @property({ signature: 'h', access: ACCESS_READ })
+    get getFdProp () {
+      return this.getLastFd();
+    }
+
+    @property({ signature: 'h', access: ACCESS_WRITE })
+    set setFdProp (fd) {
+      this.fds.push(fd);
+    }
+
+    @signal({ signature: 'h' })
+    signalFd (fd) {
+        return fd;
+    }
+
+    getLastFd() {
+        return this.fds[this.fds.length - 1];
+    }
+
+    @method({})
+    async emitSignal() {
+        const fd = await this.createFd();
+        await this.signalFd(fd);
+    }
+
+    async createFd() {
+        const fd = await openFd();
+        this.fds.push(fd);
+        return fd;
+    }
+
+    async cleanup() {
+        while (this.fds.length > 0) {
+            const fd = this.fds.pop();
+            await closeFd(fd);
+        }
+    }
+}
+
+const testIface = new TestInterface(TEST_IFACE);
+
+beforeAll(async () => {
+    await bus2.requestName(TEST_NAME);
+    bus2.export(TEST_PATH, testIface);
+});
+
+afterEach(async () => {
+    await testIface.cleanup();
+})
+
+afterAll(() => {
+    bus.disconnect();
+    bus2.disconnect();
+});
+
+test('sending file descriptor', async () => {
+    const object = await bus.getProxyObject(TEST_NAME, TEST_PATH);
+    const test = object.getInterface(TEST_IFACE);
+    expect(test).toBeDefined();
+    expect(test.returnsFd).toBeDefined();
+    const fd = await openFd();
+    await test.acceptsFd(fd);
+
+    expect(testIface.getLastFd()).toBeDefined();
+    await compareFd(fd, testIface.getLastFd());
+    await closeFd(fd);
+});
+
+
+test('receiving file descriptor', async () => {
+    const object = await bus.getProxyObject(TEST_NAME, TEST_PATH);
+    const test = object.getInterface(TEST_IFACE);
+    expect(test).toBeDefined();
+    expect(test.returnsFd).toBeDefined();
+    const fd = await test.returnsFd();
+    expect(fd).toBeDefined();
+
+    await compareFd(fd, testIface.getLastFd());
+    await closeFd(fd);
+});
+
+test('get file descriptor property', async () => {
+    const object = await bus.getProxyObject(TEST_NAME, TEST_PATH);
+    const properties = object.getInterface('org.freedesktop.DBus.Properties');
+    expect(properties).toBeDefined();
+    expect(properties.Get).toBeDefined();
+    await testIface.createFd();
+    const fdVariant = await properties.Get(TEST_IFACE, "getFdProp");
+    expect(fdVariant.signature).toEqual("h");
+    expect(fdVariant.value).toBeDefined();
+
+    await compareFd(fdVariant.value, testIface.getLastFd());
+    await closeFd(fdVariant.value);
+});
+
+test('set file descriptor property', async () => {
+    const object = await bus.getProxyObject(TEST_NAME, TEST_PATH);
+    const properties = object.getInterface('org.freedesktop.DBus.Properties');
+    expect(properties).toBeDefined();
+    expect(properties.Set).toBeDefined();
+    const fd = await openFd();
+    await properties.Set(TEST_IFACE, "setFdProp", new Variant("h", fd));
+
+    expect(testIface.getLastFd()).toBeDefined();
+    await compareFd(fd, testIface.getLastFd());
+    await closeFd(fd);
+});
+
+test('signal file descriptor', async () => {
+    const object = await bus.getProxyObject(TEST_NAME, TEST_PATH);
+    const test = object.getInterface(TEST_IFACE);
+    expect(test).toBeDefined();
+
+    let fd;
+    const onSignal = jest.fn((fd_) => fd=fd_);
+    test.on("signalFd", onSignal);
+
+    await test.emitSignal();
+
+    expect(onSignal).toHaveBeenCalled();
+
+    await compareFd(fd, testIface.getLastFd());
+    await closeFd(fd);
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -121,8 +121,8 @@ declare module 'dbus-next' {
         bus: MessageBus;
         readonly name: string;
         readonly path: ObjectPath;
-        readonly nodes: ObjectPath[];
-        readonly interfaces: { [name: string]: ClientInterface };
+        nodes: ObjectPath[];
+        interfaces: { [name: string]: ClientInterface };
 
         getInterface(name: string): ClientInterface;
         getInterface<T extends ClientInterface>(name: string): T;


### PR DESCRIPTION
Dbus allows passing of unix file descriptors using the "h" signature type.
However the spec specifies file descriptors are passed along out of band.
In case of unix domain sockets those are transported using SOL_SOCKET packet metadata.

Some DBus services e.g. Bluez rely on this functionality to hand over communication sockets to the client.

[USocket](https://github.com/jhs67/usocket) is a drop in replacement for `net.Socket` which supports handling this metadata.

This PR will use USocket in case the DBus connection is opened over a unix domain socket and then negotiate unix fd support during the handshake.

USocket is added as an optional dependency similar to abstract-socket and if its not available the native node.js socket is used without UnixFD support.
