### PR TITLE
Add support for skipping authentication

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -58,11 +58,13 @@ function hexlify (input) {
 
 module.exports = function auth (stream, opts, cb) {
   // filter used to make a copy so we don't accidently change opts data
-  let authMethods;
-  if (opts.authMethods) {
-    authMethods = opts.authMethods;
-  } else {
+  let authMethods = opts.authMethods;
+  if (opts.authMethods === undefined) {
     authMethods = constants.defaultAuthMethods;
+  }
+  const skipAuthentication = authMethods.length === 0;
+  if (skipAuthentication) {
+    return process.nextTick(() => { cb(null, null); });
   }
   stream.write('\0');
   tryAuth(stream, authMethods.slice(), cb);


### PR DESCRIPTION
By setting `authMethods` to an empty array.

Useful for peer-to-peer DBus when authentication is handled elsewhere.