### PR TITLE
Transform identifiers to look like idiomatic JavaScript

### DIFF
--- a/lib/client/proxy-interface.js
+++ b/lib/client/proxy-interface.js
@@ -1,3 +1,7 @@
+const {
+  identifierToJs,
+  identifierFromJs
+} = require('../conventions');
 const EventEmitter = require('events');
 const {
   isInterfaceNameValid,
@@ -16,7 +20,7 @@ class ProxyListener {
         console.error(`warning: got signature ${signature} for signal ${msg.interface}.${signal.name} (expected ${signal.signature})`);
         return;
       }
-      iface.emit.apply(iface, [signal.name].concat(body));
+      iface.emit.apply(iface, [identifierToJs(signal.name)].concat(body));
     };
   }
 }
@@ -78,7 +82,8 @@ class ProxyInterface extends EventEmitter {
       return [signal, detailedEvent];
     };
 
-    this.on('removeListener', (eventName, listener) => {
+    this.on('removeListener', (eventNameJs, listener) => {
+      const eventName = identifierFromJs(eventNameJs);
       const [signal, detailedEvent] = getEventDetails(eventName);
 
       if (!signal) {
@@ -103,7 +108,8 @@ class ProxyInterface extends EventEmitter {
       this.$object.bus._signals.removeListener(detailedEvent, proxyListener.fn);
     });
 
-    this.on('newListener', (eventName, listener) => {
+    this.on('newListener', (eventNameJs, listener) => {
+      const eventName = identifierFromJs(eventNameJs);
       const [signal, detailedEvent] = getEventDetails(eventName);
 
       if (!signal) {
@@ -208,7 +214,7 @@ class ProxyInterface extends EventEmitter {
         // TODO signature validation
         iface.$methods.push(method);
 
-        iface[method.name] = function (...args) {
+        iface[identifierToJs(method.name)] = function (...args) {
           const objArgs = [
             name,
             method.name,

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -1,0 +1,12 @@
+function identifierToJs (identifier) {
+  return identifier.charAt(0).toLowerCase() + identifier.slice(1);
+}
+
+function identifierFromJs (identifier) {
+  return identifier.charAt(0).toUpperCase() + identifier.slice(1);
+}
+
+module.exports = {
+  identifierToJs,
+  identifierFromJs
+};

--- a/lib/service/interface.js
+++ b/lib/service/interface.js
@@ -3,6 +3,7 @@
  *
  * @module interface
  */
+const { identifierFromJs } = require('../conventions');
 const { parseSignature, collapseSignature } = require('../signature');
 const variant = require('../variant');
 const Variant = variant.Variant;
@@ -56,10 +57,10 @@ const {
  * class MyInterface extends Interface {
  *   // uncomment below to use the decorator (jsdoc bug)
  *   //@property({signature: 's'})
- *   get MyProp() {
+ *   get myProp() {
  *     return this.myProp;
  *   }
- *   set MyProp(value) {
+ *   set myProp(value) {
  *     this.myProp = value;
  *   }
  * }
@@ -80,7 +81,7 @@ function property (options) {
   }
   options.signatureTree = parseSignature(options.signature);
   return function (descriptor) {
-    options.name = options.name || descriptor.key;
+    options.name = options.name || identifierFromJs(descriptor.key);
     assertMemberNameValid(options.name);
     descriptor.finisher = function (klass) {
       klass.prototype.$properties = klass.prototype.$properties || [];
@@ -114,12 +115,12 @@ function property (options) {
  *
  * class MyInterface extends Interface {
  *   //@method({inSignature: 's', outSignature: 's'})
- *   async Echo(what) {
+ *   async echo(what) {
  *     return what;
  *   }
  *
  *   //@method({inSignature: 'ss', outSignature: 'vv'})
- *   ReturnsMultiple(what, what2) {
+ *   returnsMultiple(what, what2) {
  *     return [
  *       new Variant('s', what),
  *       new Variant('s', what2)
@@ -127,7 +128,7 @@ function property (options) {
  *   }
  *
  *   //@method({inSignature: '', outSignature: ''})
- *   ThrowsError() {
+ *   throwsError() {
  *     // the error is returned to the client
  *     throw new DBusError('org.test.iface.Error', 'something went wrong');
  *   }
@@ -153,7 +154,7 @@ function method (options) {
   options.inSignatureTree = parseSignature(options.inSignature);
   options.outSignatureTree = parseSignature(options.outSignature);
   return function (descriptor) {
-    options.name = options.name || descriptor.key;
+    options.name = options.name || identifierFromJs(descriptor.key);
     assertMemberNameValid(options.name);
     options.fn = descriptor.descriptor.value;
     descriptor.finisher = function (klass) {
@@ -179,12 +180,12 @@ function method (options) {
  * // uncomment the decorators to use them (jsdoc bug)
  * class MyInterface extends Interface {
  *   //@signal({signature: 's'})
- *   HelloWorld(value) {
+ *   helloWorld(value) {
  *     return value;
  *   }
  *
  *   //@signal({signature: 'ss'})
- *   SignalMultiple(x) {
+ *   signalMultiple(x) {
  *     return [
  *       'hello',
  *       'world'
@@ -205,7 +206,7 @@ function signal (options) {
   options.signature = options.signature || '';
   options.signatureTree = parseSignature(options.signature);
   return function (descriptor) {
-    options.name = options.name || descriptor.key;
+    options.name = options.name || identifierFromJs(descriptor.key);
     assertMemberNameValid(options.name);
     options.fn = descriptor.descriptor.value;
     descriptor.descriptor.value = function () {
@@ -271,18 +272,18 @@ class Interface {
    * @example
    * ConfiguredInterface.configureMembers({
    *   properties: {
-   *     SomeProperty: {
+   *     someProperty: {
    *       signature: 's'
    *     }
    *   },
    *   methods: {
-   *     Echo: {
+   *     echo: {
    *       inSignature: 'v',
    *       outSignature: 'v'
    *     }
    *   },
    *   signals: {
-   *     HelloWorld: {
+   *     helloWorld: {
    *       signature: 'ss'
    *     }
    *   }
@@ -312,7 +313,7 @@ class Interface {
 
     for (const k of Object.keys(properties)) {
       const options = properties[k];
-      options.name = options.name || k;
+      options.name = options.name || identifierFromJs(k);
       options.access = options.access || ACCESS_READWRITE;
       if (!options.signature) {
         throw new Error('missing signature for property');
@@ -324,7 +325,7 @@ class Interface {
 
     for (const k of Object.keys(methods)) {
       const options = methods[k];
-      options.name = options.name || k;
+      options.name = options.name || identifierFromJs(k);
       assertMemberNameValid(options.name);
       options.disabled = !!options.disabled;
       options.inSignature = options.inSignature || '';
@@ -337,7 +338,7 @@ class Interface {
 
     for (const k of Object.keys(signals)) {
       const options = signals[k];
-      options.name = options.name || k;
+      options.name = options.name || identifierFromJs(k);
       assertMemberNameValid(options.name);
       options.fn = this.prototype[k];
       options.signature = options.signature || '';
@@ -361,7 +362,7 @@ class Interface {
    *
    * @static
    * @example
-   * Interface.emitPropertiesChanged({ SomeProperty: 'bar' }, ['InvalidedProperty']);
+   * Interface.emitPropertiesChanged({ someProperty: 'bar' }, ['invalidatedProperty']);
    *
    * @param {module:interface~Interface} - the `Interface` to emit the `PropertiesChanged` signal on
    * @param {Object} - A map of property names and new property values that are changed.
@@ -377,13 +378,14 @@ class Interface {
     // don't have to
     const properties = iface.$properties || {};
     const changedPropertiesVariants = {};
-    for (const p of Object.keys(changedProperties)) {
-      if (properties[p] === undefined) {
-        throw new Error(`got properties changed with unknown property: ${p}`);
+    for (const propNameJs of Object.keys(changedProperties)) {
+      const propName = identifierFromJs(propNameJs);
+      if (properties[propName] === undefined) {
+        throw new Error(`got properties changed with unknown property: ${propNameJs}`);
       }
-      changedPropertiesVariants[p] = new Variant(properties[p].signature, changedProperties[p]);
+      changedPropertiesVariants[propName] = new Variant(properties[propName].signature, changedProperties[propNameJs]);
     }
-    iface.$emitter.emit('properties-changed', changedPropertiesVariants, invalidatedProperties);
+    iface.$emitter.emit('properties-changed', changedPropertiesVariants, invalidatedProperties.map(identifierFromJs));
   }
 
   $introspect () {
@@ -403,7 +405,7 @@ class Interface {
       xml.property = xml.property || [];
       xml.property.push({
         $: {
-          name: property.name,
+          name: identifierFromJs(property.name),
           type: property.signature,
           access: property.access
         }
@@ -420,7 +422,7 @@ class Interface {
       xml.method = xml.method || [];
       const methodXml = {
         $: {
-          name: method.name
+          name: identifierFromJs(method.name)
         },
         arg: [],
         annotation: []
@@ -465,7 +467,7 @@ class Interface {
       xml.signal = xml.signal || [];
       const signalXml = {
         $: {
-          name: signal.name
+          name: identifierFromJs(signal.name)
         },
         arg: []
       };


### PR DESCRIPTION
Where names of properties, methods, and signals are in camelCase instead
of PascalCase.

I don't know if this would be an acceptable direction to go in, so I didn't
update the tests – but happy to do that if this is of interest.