### PR TITLE
bug: fix uncatchable thrown errror

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -173,7 +173,6 @@ class MessageBus extends EventEmitter {
       })
       .catch((err) => {
         this.emit('error', err);
-        throw new Error(err);
       });
   }
 


### PR DESCRIPTION
this is aiming to fix the error: `Uncaught (in promise) Error`, generated by the fact that it is impossible to catch the error that is thrown by the helloMessage promise --- also, that thrown seems unneeded, emitting the error should be enough in this context.