### PR TITLE
Don't loose signals when no previous method calls have been made.

### DIFF
--- a/lib/client/proxy-object.js
+++ b/lib/client/proxy-object.js
@@ -117,7 +117,25 @@ class ProxyObject {
             return reject(err);
           }
           this._initXml(data);
-          resolve(this);
+
+          const nameOwnerMessage = new Message({
+            destination: 'org.freedesktop.DBus',
+            path: '/org/freedesktop/DBus',
+            interface: 'org.freedesktop.DBus',
+            member: 'GetNameOwner',
+            signature: 's',
+            body: [this.name]
+          });
+
+          this.bus.call(nameOwnerMessage)
+            .then((msg) => {
+              this.bus._nameOwners[this.name] = msg.body[0];
+              resolve(this);
+            })
+            .catch((err) => {
+              if (err.type === 'org.freedesktop.DBus.Error.NameHasNoOwner') { return resolve(this); }
+              return reject(err);
+            });
         });
       } else {
         const introspectMessage = new Message({


### PR DESCRIPTION
ProxyInterface's listener is dropping signals if the sender does not match an already known name owner for the proxied object.

This can occur when no previous method call have been sent to this object, which is always the case for a newly XML-constructed proxy object. Moreover, if the object doesn't expose any method, it is simply impossible to get any signal from it !

In the introspection case, the initial org.freedesktop.Introspectable.Introspect call will always make the name owner initially known to the bus connection.

To prevent this, we're getting the name owner during the XML based proxy construction by querying the org.freedesktop.DBus.GetNameOwner method.

Fixes #86