### PR TITLE
add option to enable unix fd negotiation (default false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ The types `a`, `(`, `v`, and `{` are container types that hold other values. Exa
 
 For more information on the DBus type system, see [the specification](https://dbus.freedesktop.org/doc/dbus-specification.html#type-system).
 
+### Negotiating Unix File Descriptors
+
+To support negotiating Unix file descriptors (DBus type `h`), set `negotiateUnixFd` to `true` in the message bus constructor options. The value of any type `h` in messages sent or received should be the file descriptor itself. You are responsible for closing any file descriptor sent or received by the bus.
+
 ## Contributing
 
 Contributions are welcome. Development happens on [Github](https://github.com/dbusjs/node-dbus-next).

--- a/index.js
+++ b/index.js
@@ -17,9 +17,12 @@ let createClient = function(params) {
  * `DBUS_SYSTEM_BUS_ADDRESS` environment variable or
  * `unix:path=/var/run/dbus/system_bus_socket`.
  *
+ * @param {object} [options] - Options for `MessageBus` creation.
+ * @param {object} [options.negotiateUnixFd] - Whether this bus should support the negotiation of Unix file descriptors.
  */
-module.exports.systemBus = function() {
+module.exports.systemBus = function(opts) {
   return createClient({
+    negotiateUnixFd: opts.negotiateUnixFd,
     busAddress:
       process.env.DBUS_SYSTEM_BUS_ADDRESS ||
       'unix:path=/var/run/dbus/system_bus_socket'
@@ -32,6 +35,7 @@ module.exports.systemBus = function() {
  *
  * @param {object} [options] - Options for `MessageBus` creation.
  * @param {object} [options.busAddress] - The socket path for the session bus.
+ * @param {object} [options.negotiateUnixFd] - Whether this bus should support the negotiation of Unix file descriptors.
  * Defaults to finding the bus address in the manner specified in the DBus
  * specification. The bus address will first be read from the
  * `DBUS_SESSION_BUS_ADDRESS` environment variable and when that is not

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,7 +7,11 @@ const { Message } = require('./message-type');
 const { messageToJsFmt, marshallMessage } = require('./marshall-compat');
 
 function createStream (opts) {
-  let { busAddress } = opts;
+  let { busAddress, negotiateUnixFd } = opts;
+
+  if (negotiateUnixFd === undefined) {
+    negotiateUnixFd = false;
+  }
 
   // TODO according to the dbus spec, we should start a new server if the bus
   // address cannot be found.
@@ -41,18 +45,18 @@ function createStream (opts) {
             return net.createConnection(params.socket);
           }
           if (params.abstract) {
-            const usocket = require("usocket");
-            const sock = new usocket.USocket({path: '\u0000' + params.abstract});
-            sock.supportsUnixFd = true;
+            const usocket = require('usocket');
+            const sock = new usocket.USocket({ path: '\u0000' + params.abstract });
+            sock.supportsUnixFd = negotiateUnixFd;
             return sock;
           }
           if (params.path) {
             try {
-              const usocket = require("usocket");
-              const sock = new usocket.USocket({path: params.path});
-              sock.supportsUnixFd = true;
+              const usocket = require('usocket');
+              const sock = new usocket.USocket({ path: params.path });
+              sock.supportsUnixFd = negotiateUnixFd;
               return sock;
-            } catch(err) {
+            } catch (err) {
               // TODO: maybe emit warning?
               return net.createConnection(params.path);
             }
@@ -68,7 +72,7 @@ function createStream (opts) {
           for (let n = 1; params['arg' + n]; n++) args.push(params['arg' + n]);
           const child = spawn(params.path, args);
           // duplex socket is auto connected so emit connect event next frame
-          setTimeout(() => eventStream.emit("connected"), 0);
+          setTimeout(() => eventStream.emit('connected'), 0);
 
           return eventStream.duplex(child.stdin, child.stdout);
         }
@@ -130,8 +134,8 @@ function createConnection (opts) {
       opts
     );
   }
-  stream.once("connect", () => clientHandshake(stream, opts, afterHandshake));
-  stream.once("connected", () => clientHandshake(stream, opts, afterHandshake));
+  stream.once('connect', () => clientHandshake(stream, opts, afterHandshake));
+  stream.once('connected', () => clientHandshake(stream, opts, afterHandshake));
 
   self._messages = [];
 
@@ -144,8 +148,8 @@ function createConnection (opts) {
     self.state = 'connected';
     for (let i = 0; i < self._messages.length; ++i) {
       const [data, fds] = marshallMessage(self._messages[i]);
-      if(stream.supportsUnixFd) {
-        stream.write({data, fds});
+      if (stream.supportsUnixFd) {
+        stream.write({ data, fds });
       } else {
         stream.write(data);
       }
@@ -158,11 +162,11 @@ function createConnection (opts) {
         throw new Error('Cannot send message, stream is closed');
       }
       const [data, fds] = marshallMessage(msg);
-      if(stream.supportsUnixFd) {
-        stream.write({data, fds});
+      if (stream.supportsUnixFd) {
+        stream.write({ data, fds });
       } else {
-        if(fds.length > 0) {
-          console.warn("Sending file descriptors is not supported in current bus connection");
+        if (fds.length > 0) {
+          console.warn('Sending file descriptors is not supported in current bus connection');
         }
         stream.write(data);
       }

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -172,11 +172,11 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType (t) {
       return this.readSInt16();
     case 'q':
       return this.readInt16();
-    case 'h':
+    case 'h': {
       const idx = this.readInt32();
-      if(!this.fds || this.fds.length <= idx) throw new Error("No FDs available");
+      if (!this.fds || this.fds.length <= idx) throw new Error('No FDs available');
       return this.fds[idx];
-    case 'u':
+    } case 'u':
       return this.readInt32();
     case 'i':
       return this.readSInt32();

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -77,13 +77,13 @@ function tryAuth (stream, methods, cb) {
   const uid = 'getuid' in process ? process.getuid() : 0;
   const id = hexlify(uid);
 
-  let guid = "";
+  let guid = '';
   function beginOrNextAuth () {
     readLine(stream, function (line) {
       const ok = line.toString('ascii').match(/^([A-Za-z]+) (.*)/);
       if (ok && ok[1] === 'OK') {
         guid = ok[2]; // ok[2] = guid. Do we need it?
-        if(stream.supportsUnixFd) {
+        if (stream.supportsUnixFd) {
           negotiateUnixFd();
         } else {
           stream.write('BEGIN\r\n');
@@ -101,11 +101,11 @@ function tryAuth (stream, methods, cb) {
   }
   function negotiateUnixFd () {
     stream.write('NEGOTIATE_UNIX_FD\r\n');
-    readLine(stream, function(line) {
+    readLine(stream, function (line) {
       const res = line.toString('ascii').trim();
-      if (res === "AGREE_UNIX_FD") {
+      if (res === 'AGREE_UNIX_FD') {
         // ok
-      } else if(res === "ERROR") {
+      } else if (res === 'ERROR') {
         stream.supportsUnixFd = false;
       } else {
         return cb(line);

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -77,7 +77,7 @@ function write (ps, ele, data, fds) {
       write(ps, tree[0], data[1], fds);
       break;
     } case 'h': {
-      if(fds) {
+      if (fds) {
         const idx = fds.push(data);
         return writeSimple(ps, ele.type, idx - 1);
       }

--- a/test/integration/fd-passing.test.js
+++ b/test/integration/fd-passing.test.js
@@ -27,7 +27,7 @@ const TEST_NAME = 'org.test.filedescriptors';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-const bus = dbus.sessionBus();
+const bus = dbus.sessionBus({negotiateUnixFd: true});
 bus.on('error', (err) => {
     console.log(`got unexpected connection error:\n${err.stack}`);
 });
@@ -38,7 +38,7 @@ if (!bus._connection.stream.supportsUnixFd) {
     test = test.skip
 }
 
-const bus2 = dbus.sessionBus();
+const bus2 = dbus.sessionBus({negotiateUnixFd: true});
 bus2.on('error', (err) => {
     console.log(`got unexpected connection error:\n${err.stack}`);
 });


### PR DESCRIPTION
You must pass `negotiateUnixFd` to the message bus constructor to enable support for passing Unix file descriptors.