### PR TITLE
Fix typo in handling signal for NameOwnerChanged

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -102,7 +102,7 @@ class MessageBus extends EventEmitter {
         }
       } else if (msg.type === SIGNAL) {
         // if this is a name owner changed message, cache the new name owner
-        const { sender, path, iface, member } = msg;
+        const { sender, path, interface: iface, member } = msg;
         if (sender === 'org.freedesktop.DBus' &&
           path === '/org/freedesktop/DBus' &&
           iface === 'org.freedesktop.DBus' &&


### PR DESCRIPTION
Because of this typo, the logic for handling NameOwnerChanged signal didn't work