### PR TITLE
Add high level client

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -102,7 +102,7 @@ class MessageBus extends EventEmitter {
         }
       } else if (msg.type === SIGNAL) {
         // if this is a name owner changed message, cache the new name owner
-        const { sender, path, iface, member } = msg;
+        const { sender, path, interface: iface, member } = msg;
         if (sender === 'org.freedesktop.DBus' &&
           path === '/org/freedesktop/DBus' &&
           iface === 'org.freedesktop.DBus' &&

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -25,6 +25,8 @@ const {
 const ProxyObject = require('./client/proxy-object');
 
 const xmlHeader = '<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">\n';
+const nameOwnerMatchRule =
+  "type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',path='/org/freedesktop/DBus',member='NameOwnerChanged'";
 
 /**
  * @class
@@ -67,6 +69,7 @@ class MessageBus extends EventEmitter {
     this._nameOwners = {};
     this._methodHandlers = [];
     this._serviceObjects = {};
+    this._isHighLevelClientInitialized = false;
 
     // An object with match rule keys and refcount values. Used only by
     // the internal high-level function `_addMatch` for refcounting.
@@ -188,9 +191,14 @@ class MessageBus extends EventEmitter {
    * @param [xml] {string} - xml introspection data.
    * @returns {Promise} - a Promise that resolves with the `ProxyObject`.
    */
-  getProxyObject (name, path, xml) {
+  async getProxyObject (name, path, xml) {
     const obj = new ProxyObject(this, name, path);
-    return obj._init(xml);
+
+    const objInitPromise = obj._init(xml);
+
+    await this._initHighLevelClient();
+
+    return objInitPromise;
   }
 
   /**
@@ -402,6 +410,21 @@ class MessageBus extends EventEmitter {
         this._removeServiceObject(path);
       }
     }
+  }
+
+  async _initHighLevelClient () {
+    if (this._isHighLevelClientInitialized) {
+      return;
+    }
+
+    try {
+      await this._addMatch(nameOwnerMatchRule);
+    } catch (error) {
+      this.emit("error", error);
+      return;
+    }
+
+    this._isHighLevelClientInitialized = true;
   }
 
   _introspect (path) {

--- a/lib/client/proxy-interface.js
+++ b/lib/client/proxy-interface.js
@@ -128,7 +128,7 @@ class ProxyInterface extends EventEmitter {
   }
 
   _signalMatchRuleString (eventName) {
-    return `type='signal',sender=${this.$object.name},interface='${this.$name}',path='${this.$object.path}',member='${eventName}'`;
+    return `type='signal',sender='${this.$object.name}',interface='${this.$name}',path='${this.$object.path}',member='${eventName}'`;
   }
 
   _getEventListener (signal) {

--- a/test/util.js
+++ b/test/util.js
@@ -10,6 +10,24 @@ async function ping (bus) {
   }));
 }
 
+/**
+ * Waits for a message that passes a filter on a provided bus.
+ */
+function waitForMessage(bus, messageFilter) {
+  return new Promise((resolve) => {
+    bus.on('message', (message) => {
+      const isMessageValid = Object.entries(messageFilter).every(
+        ([key, value]) => message[key] === value
+      );
+
+      if (isMessageValid) {
+        resolve();
+      }
+    });
+  });
+}
+
 module.exports = {
-  ping: ping
+  ping,
+  waitForMessage,
 };


### PR DESCRIPTION
# Branched from https://github.com/dbusjs/node-dbus-next/pull/95

High level client automatically subscribes to NameOwnerChanged signal once proxy object is retrieved.