### PR TITLE
pass opts along to createClient in systemBus

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports.systemBus = function(opts) {
   if(!opts)
     opts = {};
   return createClient({
+    ...opts,
     negotiateUnixFd: opts.negotiateUnixFd,
     busAddress:
       process.env.DBUS_SYSTEM_BUS_ADDRESS ||


### PR DESCRIPTION
Hello!

  Love the library, but I noticed that `systemBus`, unlike `sessionBus`, doesn't pass `opts` down the chain. I've added this, so that I can `.systemBus({ authMethods: ['ANONYMOUS'] })`

Thanks!