### PR TITLE
Attempt to fix match leaks

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -483,7 +483,7 @@ class MessageBus extends EventEmitter {
   }
 
   _addMatch (match) {
-    if (Object.prototype.hasOwnProperty.call(match, this._matchRules)) {
+    if (Object.prototype.hasOwnProperty.call(this._matchRules, match)) {
       this._matchRules[match] += 1;
       return Promise.resolve();
     }
@@ -507,7 +507,7 @@ class MessageBus extends EventEmitter {
       return Promise.resolve();
     }
 
-    if (Object.prototype.hasOwnProperty.call(match, this._matchRules)) {
+    if (Object.prototype.hasOwnProperty.call(this._matchRules, match)) {
       this._matchRules[match] -= 1;
       if (this._matchRules[match] > 0) {
         return Promise.resolve();


### PR DESCRIPTION
Hello,

I got notices of "matches" accumulating while using another library [1] using this library for dbus communication. Traced it until `MessageBus._addMatch`/`MessageBus._removeMatch` which seems to get called properly. However, the dbus messages `AddMatch` and `RemoveMatch` does not. That is, I could not observe a `RemoveMatch` message for every `AddMatch` message.

This PR attempts to correct the property check on the counter. Should be the same as `this._matchRules.hasOwnProperty(match)` as far as I can see.

For my test case the proper `RemoveMatch` messages get sent as well after this change.

I didn't have a deeper look at the logic. If not the proper solution, maybe it can serve as a description of the issue :)

[1] https://github.com/chrvadala/node-ble/issues/36