### PR TITLE
Add export of MessageBus to match types.d.ts

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,3 +69,4 @@ module.exports.Variant = Variant;
 module.exports.Message = Message;
 module.exports.validators = require('./lib/validators');
 module.exports.DBusError = errors.DBusError;
+module.exports.MessageBus = MessageBus;


### PR DESCRIPTION
The MessageBus class is declared as exported in the types.d.ts file, but in reality it is not exported in the index.js file. This causes weird and hard to troubleshoot errors when trying to extend the MessageBus class in typescript.