### PR TITLE
Handle message without interface name

### DIFF
--- a/lib/service/handlers.js
+++ b/lib/service/handlers.js
@@ -273,11 +273,11 @@ function handleMessage (msg, bus) {
     signature
   } = msg;
 
-  const ifaceName = msg.interface;
+  let ifaceName = msg.interface;
 
   signature = signature || '';
 
-  if (handleStdIfaces(bus, msg)) {
+  if (ifaceName && handleStdIfaces(bus, msg)) {
     return true;
   }
 
@@ -286,6 +286,9 @@ function handleMessage (msg, bus) {
   }
 
   const obj = bus._getServiceObject(path);
+  if (!ifaceName && Object.keys(obj.interfaces).length > 0){
+	  ifaceName = Object.keys(obj.interfaces)[0];
+  }
   const iface = obj.interfaces[ifaceName];
 
   if (!iface) {


### PR DESCRIPTION
VictronOS devices sometimes call a method on a dbus interface while passing a null interface name. This change adds the ability to handle this by using the first interface name in the list of interfaces only if null has been passed and it is not one of the standard interfaces.